### PR TITLE
TFT35_V2.0

### DIFF
--- a/firmware/TFT35/src/User/API/UI/touch_process.c
+++ b/firmware/TFT35/src/User/API/UI/touch_process.c
@@ -26,7 +26,7 @@
 #define K TSC_Para[6]
 
 
-u32 TSC_Para[7];//У׼ϵ��
+u32 TSC_Para[7];//Ð£×¼Ïµï¿½ï¿½
 static volatile bool touchScreenIsPress=false;
 
 void TS_Get_Coordinates(u16 *x, u16 *y)
@@ -81,7 +81,7 @@ u8 calibrationEnsure(u16 x,u16 y)
   }
   return 1;
 }
-
+//´¥ÃþÐ£×¼
 void TSC_Calibration(void)
 {
   u16 x_offset;
@@ -216,11 +216,11 @@ typedef enum
   LONG_PRESS,
 }KEY_STATUS;
 
-#define KEY_DOUOBLE_SPACE        15     //�೤ʱ���ڵ�������ж�Ϊ˫��
-#define KEY_LONG_PRESS_START     200     //��������ÿ�ʼ�ж�Ϊ ���� ��ֵ
+#define KEY_DOUOBLE_SPACE        15     //ï¿½à³¤Ê±ï¿½ï¿½ï¿½Úµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ð¶ï¿½ÎªË«ï¿½ï¿½
+#define KEY_LONG_PRESS_START     200     //ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ã¿ï¿½Ê¼ï¿½Ð¶ï¿½Îª ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Öµ
 
-#define KEY_LONG_PRESS_SPACE_MAX 10     //����ʱ ���÷���һ�μ�ֵ
-#define KEY_LONG_PRESS_SPACE_MIN 2      //����ʱ ��̶�÷���һ�μ�ֵ
+#define KEY_LONG_PRESS_SPACE_MAX 10     //ï¿½ï¿½ï¿½ï¿½Ê± ï¿½î³¤ï¿½ï¿½Ã·ï¿½ï¿½ï¿½Ò»ï¿½Î¼ï¿½Öµ
+#define KEY_LONG_PRESS_SPACE_MIN 2      //ï¿½ï¿½ï¿½ï¿½Ê± ï¿½ï¿½Ì¶ï¿½Ã·ï¿½ï¿½ï¿½Ò»ï¿½Î¼ï¿½Öµ
 
 //u16 KEY_GetValue(u8 total_rect,const GUI_RECT* menuRect)
 //{
@@ -230,7 +230,7 @@ typedef enum
 //  static u32  first_time = 0;
 //  static u8   long_press_space = KEY_LONG_PRESS_SPACE_MAX;
 
-//  static KEY_STATUS nowStatus = NO_CLICK;    //������ǰ��״̬
+//  static KEY_STATUS nowStatus = NO_CLICK;    //ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ç°ï¿½ï¿½×´Ì¬
 
 //  if(touchScreenIsPress)        
 //  {
@@ -396,13 +396,13 @@ void TIM3_Config(u16 psc,u16 arr)
 	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE; 
 	NVIC_Init(&NVIC_InitStructure); 
 
-	RCC->APB1ENR|=1<<1;	           //TIM3ʱ��ʹ��    
- 	TIM3->ARR=arr;  	             //�趨�Զ���װֵ   
-	TIM3->PSC=psc;  	             //Ԥ��Ƶ��
-  TIM3->SR = (uint16_t)~(1<<0);  //��������ж�
-	TIM3->DIER|=1<<0;              //���������ж�	  
+	RCC->APB1ENR|=1<<1;	           //TIM3Ê±ÖÓÊ¹ÄÜ    
+ 	TIM3->ARR=arr;  	             //Éè¶¨×Ô¶¯ÖØ×°Öµ   
+	TIM3->PSC=psc;  	             //Ô¤·ÖÆµÆ÷
+  TIM3->SR = (uint16_t)~(1<<0);  //Çå³ý¸üÐÂÖÐ¶Ï
+	TIM3->DIER|=1<<0;              //ÔÊÐí¸üÐÂÖÐ¶Ï	  
 	TIM3->CNT =0;
-	TIM3->CR1 &= ~(0x01);          //ʧ�ܶ�ʱ��3	
+	TIM3->CR1 &= ~(0x01);          //Ê§ÄÜ¶¨Ê±Æ÷3	
 }
 
 void Buzzer_Config(void)
@@ -427,6 +427,48 @@ void Buzzer_DeConfig(void)
   GPIO_InitStructure.GPIO_Pin = BUZZER_PIN;
   GPIO_Init(BUZZER_PORT, &GPIO_InitStructure);
 }
+//´òÍê¹Ø»ú³õÊ¼»¯ÅäÖÃ
+void PS_ON_Config(void)
+{
+  GPIO_InitTypeDef GPIO_InitStructure;
+  
+  RCC_APB2PeriphClockCmd(PS_ON_RCC, ENABLE);
+
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
+  GPIO_InitStructure.GPIO_Pin = PS_ON_PIN;
+  GPIO_InitStructure.GPIO_Speed =GPIO_Speed_50MHz;
+  GPIO_Init(PS_ON_PORT, &GPIO_InitStructure);
+    
+  GPIO_SetBits(GPIOE,  GPIO_Pin_5);  
+}
+void PS_ON_DeConfig(void)
+{
+  GPIO_InitTypeDef GPIO_InitStructure;  
+
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
+  GPIO_InitStructure.GPIO_Pin = PS_ON_PIN;
+  GPIO_Init(PS_ON_PORT, &GPIO_InitStructure);
+}
+//¶ÏÁÏ¼ì²âÅäÖÃ
+void Material_Check_DeConfig(void)
+{
+  GPIO_InitTypeDef GPIO_InitStructure;  
+
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
+  GPIO_InitStructure.GPIO_Pin = Material_Check_PIN;
+  GPIO_Init(Material_Check_PORT, &GPIO_InitStructure);
+}
+void Material_Check_Config(void)
+{
+  GPIO_InitTypeDef GPIO_InitStructure;
+  
+  RCC_APB2PeriphClockCmd(Material_Check_RCC, ENABLE);
+
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+  GPIO_InitStructure.GPIO_Pin = Material_Check_PIN;
+  GPIO_InitStructure.GPIO_Speed =GPIO_Speed_50MHz;
+  GPIO_Init(Material_Check_PORT, &GPIO_InitStructure);
+}
 
 typedef struct{
 	u16 h_us,
@@ -446,7 +488,7 @@ void openBuzzer(u16 h_us, u16 l_us)
   else
     buzzer.num = 500;        
 
-  TIM3->CR1 |= 0x01;               //ʹ�ܶ�ʱ��3	
+  TIM3->CR1 |= 0x01;               //Ê¹ÄÜ¶¨Ê±Æ÷3	
 }
 void closeBuzzer(void)   
 {
@@ -454,10 +496,10 @@ void closeBuzzer(void)
 	TIM3->CR1 &= ~(0x01);
 }
 
-void TIM3_IRQHandler(void)   //TIM3�ж�
+void TIM3_IRQHandler(void)   //TIM3ÖÐ¶Ï
 {
   static bool flag = false;
-  if ((TIM3->SR&0x01) != 0 ) //���ָ����TIM�жϷ������:TIM �ж�Դ 
+  if ((TIM3->SR&0x01) != 0 ) //¼ì²éÖ¸¶¨µÄTIMÖÐ¶Ï·¢ÉúÓë·ñ:TIM ÖÐ¶ÏÔ´ 
   {
     flag = !flag;
     if( flag )
@@ -477,7 +519,7 @@ void TIM3_IRQHandler(void)   //TIM3�ж�
       TIM3->CR1 &= ~(0x01);
     }
 
-    TIM3->SR = (uint16_t)~(1<<0);  //���TIMx���жϴ�����λ:TIM �ж�Դ 
+    TIM3->SR = (uint16_t)~(1<<0);  //Çå³ýTIMxµÄÖÐ¶Ï´ý´¦ÀíÎ»:TIM ÖÐ¶ÏÔ´ 
   }
 }
 #endif

--- a/firmware/TFT35/src/User/API/UI/touch_process.h
+++ b/firmware/TFT35/src/User/API/UI/touch_process.h
@@ -13,10 +13,10 @@ enum
   KNOB_DEC,
 };
 
-#define KEY_CLICK          0x0000  // key定义为 u16, 16(u16 16bit) - 3(3 bits flag ) = 13 bit 所以 u16 最大支持 2^13 = 8192 个键值
-#define KEY_DOUBLE_CLICK   0x2000  //第三位用来标识双击动作
-#define KEY_LONG_RELEASE   0x4000  //第二位用来标识长按后释放动作
-#define KEY_LONG_CLICK     0x8000  //第一位用来标识长按动作
+#define KEY_CLICK          0x0000  // key露篓脪氓脦陋 u16, 16(u16 16bit) - 3(3 bits flag ) = 13 bit 脣霉脪脭 u16 脳卯麓贸脰搂鲁脰 2^13 = 8192 赂枚录眉脰碌
+#define KEY_DOUBLE_CLICK   0x2000  //碌脷脠媒脦禄脫脙脌麓卤锚脢露脣芦禄梅露炉脳梅
+#define KEY_LONG_RELEASE   0x4000  //碌脷露镁脦禄脫脙脌麓卤锚脢露鲁陇掳麓潞贸脢脥路脜露炉脳梅
+#define KEY_LONG_CLICK     0x8000  //碌脷脪禄脦禄脫脙脌麓卤锚脢露鲁陇掳麓露炉脳梅
 
 
 void TSC_Calibration(void);
@@ -30,6 +30,10 @@ extern void (*TSC_ReDrawIcon)(u8 positon, u8 is_press);
 
 void Buzzer_Config(void);
 void Buzzer_DeConfig(void);
+void PS_ON_Config(void);                        //麓貌脥锚鹿脴禄煤鲁玫脢录禄炉脜盲脰脙
+void PS_ON_DeConfig(void);                      //麓貌脥锚鹿脴禄煤脜盲脰脙赂麓脦禄
+void Material_Check_DeConfig(void);             //露脧脕脧录矛虏芒赂麓脦禄脜盲脰脙
+void Material_Check_Config(void);               //露脧脕脧录矛虏芒鲁玫脢录禄炉脜盲脰脙
 void openBuzzer(u16 h_us, u16 l_us);
 
 #endif

--- a/firmware/TFT35/src/User/API/interfaceCmd.c
+++ b/firmware/TFT35/src/User/API/interfaceCmd.c
@@ -135,7 +135,10 @@ void sendQueueCmd(void)
         case 27: //M27
           printSetUpdateWaiting(false);
         break;
-        
+        case 81: //M81
+            GPIO_ResetBits(GPIOE,  GPIO_Pin_5);//¹Ø»úÖ¸Áî
+        break ;
+          
         case 82: //M82
           eSetRelative(false);
         break;

--- a/firmware/TFT35/src/User/Menu/Mode.c
+++ b/firmware/TFT35/src/User/Menu/Mode.c
@@ -6,18 +6,38 @@ void Serial_ReSourceDeInit(void)
 {
   memset(&infoHost, 0, sizeof(infoHost));
   resetInfoFile();
-  SD_DeInit();
+//  SD_DeInit();
+  SD_Init();
 #ifdef BUZZER_SUPPORT
   Buzzer_DeConfig();
 #endif
+//
+#ifdef PS_ON_SUPPORT     //´òÍê¹Ø»ú
+  PS_ON_DeConfig();
+#endif 
+//  
+#ifdef Material_Check_SUPPORT //¶ÏÁÏ¼ì²â 
+  Material_Check_DeConfig();
+#endif  
+    
   Serial_DeConfig();
 }
 
 void Serial_ReSourceInit(void)
 {
+//·äÃùÆ÷
 #ifdef BUZZER_SUPPORT
   Buzzer_Config();
 #endif
+//´òÍê¹Ø»ú
+#ifdef PS_ON_SUPPORT
+  PS_ON_Config();
+#endif 
+//¶ÏÁÏ¼ì²â    
+#ifdef Material_Check_SUPPORT
+  Material_Check_Config();
+#endif 
+    
   Serial_Config(infoSettings.baudrate);
   
 #ifdef U_DISK_SUPPROT
@@ -37,7 +57,7 @@ void infoMenuSelect(void)
       u32 startUpTime = OS_GetTime();
       heatSetUpdateTime(100);
       infoMenu.menu[infoMenu.cur] = menuMain;
-      LOGO_ReadDisplay();
+      LOGO_ReadDisplay();                       //ÏÔÊ¾¿ª»úlogo
       while(OS_GetTime() - startUpTime < 300)  //Display 3s logo
       {                                                                                                                     
         loopProcess();	

--- a/firmware/TFT35/src/User/Menu/menu.c
+++ b/firmware/TFT35/src/User/Menu/menu.c
@@ -217,6 +217,27 @@ KEY_VALUES menuKeyGetValue(void)
   return(KEY_VALUES)KEY_GetValue(sizeof(rect_of_key)/sizeof(rect_of_key[0]), rect_of_key);    
 }
 
+//断料检测
+void Material_Check(void)
+{
+    if((GPIO_ReadInputDataBit(GPIOE ,GPIO_Pin_6)==1) && T_count>10){
+        T_count-=3;
+        //提示断料
+        Material_Check_flag=1;
+        
+//        popupDrawPage(bottomDoubleBtn, textSelect(LABEL_PAUSE), (u8*)"Supplies are out of stock or broken,please stop printing", textSelect(LABEL_CONFIRM), textSelect(LABEL_CANNEL));
+    }
+    else if(GPIO_ReadInputDataBit(GPIOE ,GPIO_Pin_6)==0){
+        T_count++;
+        if(T_count>12){
+            T_count=0;
+            inCheck_flag=1;
+            
+            Material_Check_flag=0;
+        }
+
+    }
+}
 
 void loopProcess (void)
 {
@@ -249,4 +270,18 @@ void loopProcess (void)
   if(!isPrinting())
     loopCheckMode();
 #endif
+/*************断料检测************************************/
+  if(isPrinting()){
+     if(isPause()!=1)
+      Material_Check();
+  }
+  if(Material_Check_flag == 1 && inCheck_flag ==1){
+//    Material_Check_flag =0;
+    inCheck_flag = 0;
+      setPrintPause(1); 
+    popupDrawPage(&bottomSingleBtn, textSelect(LABEL_PAUSE), (u8*)"No Material!", textSelect(LABEL_CONFIRM), 0);
+    if(infoMenu.menu[infoMenu.cur] != menuPopup)
+    infoMenu.menu[++infoMenu.cur] = menuPopup;
+  }
+/****************************************************/
 }

--- a/firmware/TFT35/src/User/variants.h
+++ b/firmware/TFT35/src/User/variants.h
@@ -8,14 +8,14 @@
 */
 
 //MCU type (STM32F103VC - HD, STM32F105 - CL)
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT35_V3_0) || defined(TFT28)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT35_V3_0) || defined(TFT28)//||defined(TFT35_V2_0)
   #define STM32F10X_HD
 #elif defined(TFT24_V1_1)
   #define STM32F10X_CL
 #endif
 
 //HSE crystal frequency
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2)|| defined(TFT28)  
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2)|| defined(TFT28)||defined(TFT35_V2_0) 
   #define HSE_VALUE ((uint32_t)16000000) //16Mhz
 #elif defined(TFT24_V1_1) || defined(TFT35_V3_0) 
   #define HSE_VALUE ((uint32_t)8000000) //8Mhz
@@ -26,7 +26,7 @@
   #define RM68042
   #define STM32_HAS_FSMC
   #define LCD_DATA_16BIT 0
-#elif defined(TFT35_V1_2) || defined(TFT35_V3_0)
+#elif defined(TFT35_V1_2) || defined(TFT35_V3_0)||defined(TFT35_V2_0)
   #define ILI9488
   #define STM32_HAS_FSMC
   #define LCD_DATA_16BIT 1
@@ -41,7 +41,7 @@
 #endif
 
 //LCD Backlight pin (PWM can adjust brightness)
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)||defined(TFT35_V2_0)
   //don't support LCD Backlight pin
 #elif defined(TFT24_V1_1)
   #define LCD_LED_SUPPORT
@@ -55,7 +55,7 @@
   #define LCD_LED_PIN   GPIO_Pin_12
 #endif
 
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT24_V1_1)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT24_V1_1)||defined(TFT35_V2_0)
   #define SERIAL_PORT   _USART1  //default usart port
 #elif defined(TFT35_V3_0)
   #define SERIAL_PORT   _USART2  //
@@ -87,6 +87,19 @@
   #define XPT2046_MOSI_PIN  GPIO_Pin_0
   #define XPT2046_TPEN_PORT GPIOA
   #define XPT2046_TPEN_PIN  GPIO_Pin_15
+#elif defined(TFT35_V2_0)
+  #define XPT2046_GPIO_RCC  RCC_APB2Periph_GPIOC|RCC_APB2Periph_GPIOB
+  #define XPT2046_CS_PORT   GPIOC
+  #define XPT2046_CS_PIN    GPIO_Pin_0
+  #define XPT2046_SCK_PORT  GPIOB
+  #define XPT2046_SCK_PIN   GPIO_Pin_3
+  #define XPT2046_MISO_PORT GPIOB
+  #define XPT2046_MISO_PIN  GPIO_Pin_4
+  #define XPT2046_MOSI_PORT GPIOB
+  #define XPT2046_MOSI_PIN  GPIO_Pin_5
+  #define XPT2046_TPEN_PORT GPIOC
+  #define XPT2046_TPEN_PIN  GPIO_Pin_1  
+ 
 #elif defined(TFT35_V3_0)
   #define XPT2046_GPIO_RCC  RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOE
   #define XPT2046_CS_PORT   GPIOE
@@ -119,6 +132,7 @@
   #define SPI1_CS_PORT  GPIOA
   #define SPI1_CS_PIN   GPIO_Pin_4
 #endif
+//SD Card Pins
 
 //SD Card CD detect pin
 #if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2)
@@ -141,7 +155,7 @@
 #endif
 
 //W25Qxx SPI pins
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)||defined(TFT35_V2_0)
   #define W25Qxx_SPEED  1
   #define W25Qxx_SPI    _SPI1
   #define SPI1_CS_RCC   RCC_APB2Periph_GPIOA
@@ -181,10 +195,31 @@
   #define BUZZER_RCC   RCC_APB2Periph_GPIOD
   #define BUZZER_PORT  GPIOD
   #define BUZZER_PIN   GPIO_Pin_13
+#elif defined(TFT35_V2_0)
+  #define BUZZER_SUPPORT
+  #define BUZZER_RCC   RCC_APB2Periph_GPIOB
+  #define BUZZER_PORT  GPIOB
+  #define BUZZER_PIN   GPIO_Pin_2
+#endif
+
+//PS_ON Support 
+#if defined(TFT35_V2_0)
+  #define PS_ON_SUPPORT
+  #define PS_ON_RCC   RCC_APB2Periph_GPIOE
+  #define PS_ON_PORT  GPIOE
+  #define PS_ON_PIN   GPIO_Pin_5
+#endif
+
+//Material Check
+#if defined(TFT35_V2_0)
+  #define Material_Check_SUPPORT
+  #define Material_Check_RCC   RCC_APB2Periph_GPIOE
+  #define Material_Check_PORT  GPIOE
+  #define Material_Check_PIN   GPIO_Pin_6
 #endif
 
 //LCD Encoder support
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28)||defined(TFT35_V2_0)
   //don't support LCD Encoder
 #elif defined(TFT24_V1_1)
   #define LCD_ENCODER_SUPPORT
@@ -209,14 +244,15 @@
 #endif
 
 //U disk support
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT35_V3_0)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT35_V3_0)||defined(TFT35_V2_0)
+
 #elif defined(TFT24_V1_1)
   #define U_DISK_SUPPROT
   #define USE_USB_OTG_FS
 #endif
 
 //LCD resolution, font and icon size
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT35_V3_0)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT35_V3_0)||defined(TFT35_V2_0)
   #define LCD_WIDTH	  480
   #define LCD_HEIGHT	320
   #define BYTE_HEIGHT 24
@@ -235,7 +271,7 @@
 #endif
 
 //Debug disable, free pins for other function
-#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT35_V3_0)
+#if defined(TFT35_V1_0) || defined(TFT35_V1_1) || defined(TFT35_V1_2) || defined(TFT28) || defined(TFT35_V3_0)||defined(TFT35_V2_0)
   #define DISABLE_JTAG    //free JTAG(PB3/PB4) for SPI3
 #elif defined(TFT24_V1_1)
   #define DISABLE_DEBUG   //
@@ -248,6 +284,8 @@
   #define HARDWARE_VERSION "TFT35_V1.1"
 #elif defined(TFT35_V1_2)
   #define HARDWARE_VERSION "TFT35_V1.2"
+#elif defined(TFT35_V2_0)
+  #define HARDWARE_VERSION "TFT35_V2.0"
 #elif defined(TFT35_V3_0)
   #define HARDWARE_VERSION "TFT35_V3.0"
 #elif defined(TFT28)


### PR DESCRIPTION
1.Add shutdown function after printing
2.Added material break detection function
3.If you want to use tft3.5V2.0, change the version number of tft35 in Option for target, under the c/c++ menu bar.